### PR TITLE
ci: Remove duplicate unit test step from workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,12 +75,6 @@ jobs:
     - name: Run type checking
       run: bunx tsc --noEmit
 
-    - name: Run unit tests
-      run: bun run test
-      env:
-        # Only required for ApiKeyStoreService constructor
-        API_STORE_ENCRYPTION_KEY: test-encryption-key-32-bytes-long
-
     - name: Run tests with coverage
       run: bun run test:cov
       env:


### PR DESCRIPTION
## Summary
- Removed redundant 'Run unit tests' step from CI workflow
- Tests are already executed in the 'Run tests with coverage' step
- Improves CI efficiency by eliminating duplicate test execution

## Test plan
- [x] Verify CI workflow still runs all tests via coverage step
- [x] Confirm no functionality is lost by removing duplicate step
- [x] Check that all existing CI checks continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)