### PR TITLE
feat: implement complete Plaid adapter with comprehensive test suite

### DIFF
--- a/packages/splice-service/src/data-sources/adapters/scraper.adapter.ts
+++ b/packages/splice-service/src/data-sources/adapters/scraper.adapter.ts
@@ -1,5 +1,11 @@
 import { BadRequestException, Injectable, Logger } from '@nestjs/common';
-import { BankConnection, DataSourceAdapter, StandardizedAccount, StandardizedTransaction } from 'splice-api';
+import {
+  BankConnection,
+  DataSourceAdapter,
+  StandardizedAccount,
+  StandardizedAccountType,
+  StandardizedTransaction,
+} from 'splice-api';
 import { z } from 'zod';
 import { ScraperService } from '../../scraper/scraper.service';
 
@@ -64,7 +70,7 @@ export class ScraperAdapter implements DataSourceAdapter {
       {
         id: `${connection.id}-default`,
         name: connection.bank.name,
-        type: 'OTHER',
+        type: StandardizedAccountType.OTHER,
         institution: connection.bank.name,
         metadata: {
           connectionId: connection.id,


### PR DESCRIPTION
## Summary
- Implemented full Plaid account fetching functionality with vault integration
- Added StandardizedAccountType enum and enhanced account/balance interfaces to splice-api
- Created comprehensive test suite with 32 new tests covering all adapter functionality
- Updated scraper adapter to use new standardized account type enum

## Changes Made

### API Types Enhancement (`splice-api`)
- Added `StandardizedAccountType` enum for consistent account type handling
- Enhanced `StandardizedAccount` interface with proper balance structure and metadata
- Added `StandardizedAccountBalances` interface with detailed balance information

### Plaid Adapter Implementation (`plaid.adapter.ts`)
- ✅ Added VaultService dependency for secure credential management
- ✅ Implemented `fetchAccounts()` to actually fetch accounts from Plaid API
- ✅ Added `plaidAccountToStandardizedAccount()` for data transformation
- ✅ Added `plaidAccountTypeToStandardizedAccountType()` for type conversion
- ✅ Proper error handling for missing auth details and validation failures
- ✅ Removed debug console.log statements

### Scraper Adapter Update
- Updated to use `StandardizedAccountType.OTHER` instead of string literal

### Comprehensive Test Suite (`plaid.adapter.spec.ts`)
- ✅ **32 total tests** covering all functionality:
  - Constructor validation and initialization (5 tests)
  - Connection initiation with error scenarios (4 tests) 
  - Payload validation with edge cases (8 tests)
  - Account fetching with comprehensive scenarios (5 tests)
  - Account type conversion logic (6 tests)
  - Account object transformation (4 tests)
- ✅ Full mock setup for PlaidApi, VaultService, and ConfigService
- ✅ Error scenario testing for validation failures, missing auth, invalid JSON
- ✅ Proper TypeScript typing with complete AccountBase mock objects

## Test Plan
- [x] All existing tests pass (160 total tests)
- [x] New Plaid adapter tests pass (32 new tests)
- [x] Linting passes with no critical errors
- [x] Type checking passes after building splice-api package
- [x] Constructor properly validates required environment variables
- [x] Account fetching integrates with VaultService for credential retrieval
- [x] Account type conversion handles all Plaid account types correctly
- [x] Error handling works for all failure scenarios

## Breaking Changes
None - this is purely additive functionality that enhances the existing Plaid adapter without breaking existing interfaces.

🤖 Generated with [Claude Code](https://claude.ai/code)