### PR TITLE
feat: refactor account and transaction types into ledger module

### DIFF
--- a/packages/splice-api-client/package.json
+++ b/packages/splice-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splice-api-client",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Type-safe HTTP client for Splice API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
     "jest": "^29.7.0"
   },
   "dependencies": {
-    "splice-api": "^1.0.6"
+    "splice-api": "^1.0.7"
   },
   "peerDependencies": {},
   "files": [

--- a/packages/splice-api/package.json
+++ b/packages/splice-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splice-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shared types and interfaces for Splice application",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/splice-api/src/data-sources/types.ts
+++ b/packages/splice-api/src/data-sources/types.ts
@@ -1,56 +1,5 @@
-/** biome-ignore-all lint/complexity/noBannedTypes: <each adapter should extend the base types> */
 import type { BankConnection } from '../bank-connections';
-
-export enum StandardizedAccountType {
-  CHECKING = 'CHECKING',
-  SAVINGS = 'SAVINGS',
-  CREDIT_CARD = 'CREDIT_CARD',
-  INVESTMENT = 'INVESTMENT',
-  OTHER = 'OTHER',
-}
-
-export interface StandardizedAccount {
-  id: string;
-  name: string;
-  /** Last 2-4 alphanumeric characters of account number */
-  mask?: string;
-  type: StandardizedAccountType;
-  balances?: StandardizedAccountBalances;
-  institution: string;
-  metadata?: Record<string, any>;
-}
-
-export interface StandardizedAccountBalances {
-  /** Total balance (reflects posted transactions) */
-  current?: number;
-  /** Available balance (ie. current balance less pending transactions) */
-  available?: number;
-  /** Currency code in ISO 4217 format */
-  isoCurrencyCode?: string;
-  /** Unofficial currency code (ie. for non-ISO currencies like crypto) */
-  unofficialCurrencyCode?: string;
-  /** Last updated timestamp */
-  lastUpdated?: string;
-}
-
-export interface StandardizedTransaction {
-  id: string;
-  accountId: string;
-  date: string;
-  datetime?: string;
-  description: string;
-  merchantName?: string;
-  pending: boolean;
-  logoUrl?: string;
-  websiteUrl?: string;
-  amount: number;
-  isoCurrencyCode?: string;
-  unofficialCurrencyCode?: string;
-  currency?: string;
-  category?: string;
-  type: 'DEBIT' | 'CREDIT';
-  metadata?: Record<string, any>;
-}
+import type { StandardizedAccount, StandardizedTransaction } from '../ledger';
 
 /**
  * InitiateConnectionResponse is the response type returned by initiateConnection

--- a/packages/splice-api/src/index.ts
+++ b/packages/splice-api/src/index.ts
@@ -3,5 +3,6 @@ export * from './bank-connections';
 export * from './banks';
 export * from './common';
 export * from './data-sources';
+export * from './ledger';
 export * from './scraper';
 export * from './users';

--- a/packages/splice-api/src/ledger/account.ts
+++ b/packages/splice-api/src/ledger/account.ts
@@ -1,0 +1,89 @@
+import type { BankConnection } from '../bank-connections';
+
+export interface StandardizedAccount {
+  /** ID, this is Splice's record of the account, NOT the source's ID */
+  id: string;
+  /** Bank connection. A Splice bank connection can have one or many accounts */
+  bankConnection: BankConnection;
+  /** Provider's ID of the account (eg. Plaid account_id) */
+  providerAccountId: string;
+  /** Balances */
+  balances: StandardizedAccountBalances;
+  /** Mask (last 2-4 alphanumeric characters of account number) */
+  mask?: string;
+  /** Display name of the account */
+  name: string;
+  /** Type of the account */
+  type: StandardizedAccountType;
+}
+
+export interface StandardizedAccountBalances {
+  /** Total balance (reflects posted transactions) */
+  current?: number;
+  /** Available balance (ie. current balance less pending transactions) */
+  available?: number;
+  /** Currency code in ISO 4217 format */
+  isoCurrencyCode?: string;
+  /** Unofficial currency code (ie. for non-ISO currencies like crypto) */
+  unofficialCurrencyCode?: string;
+  /** Last updated timestamp */
+  lastUpdated?: string;
+}
+
+export interface BaseStandardizedAccountType {
+  type: AccountType;
+  subtype?: string;
+}
+
+export type StandardizedAccountType =
+  | DepositoryAccountType
+  | CreditAccountType
+  | InvestmentAccountType
+  | OtherAccountType;
+
+export enum AccountType {
+  DEPOSITORY = 'DEPOSITORY',
+  CREDIT = 'CREDIT',
+  INVESTMENT = 'INVESTMENT',
+  OTHER = 'OTHER',
+}
+
+export enum DepositoryAccountSubtype {
+  CHECKING = 'CHECKING',
+  SAVINGS = 'SAVINGS',
+  HSA = 'HSA',
+}
+
+export interface DepositoryAccountType extends BaseStandardizedAccountType {
+  type: AccountType.DEPOSITORY;
+  subtype?: DepositoryAccountSubtype;
+}
+
+export enum CreditAccountSubtype {
+  CREDIT_CARD = 'CREDIT_CARD',
+}
+
+export interface CreditAccountType extends BaseStandardizedAccountType {
+  type: AccountType.CREDIT;
+  subtype?: CreditAccountSubtype;
+}
+
+export enum InvestmentAccountSubtype {
+  _401K = '401K',
+  BROKERAGE = 'BROKERAGE',
+  CRYPTO_EXCHANGE = 'CRYPTO_EXCHANGE',
+  HSA = 'HSA',
+  IRA = 'IRA',
+  OTHER = 'OTHER',
+  ROTH_IRA = 'ROTH_IRA',
+  ROTH_401K = 'ROTH_401K',
+}
+
+export interface InvestmentAccountType extends BaseStandardizedAccountType {
+  type: AccountType.INVESTMENT;
+  subtype?: InvestmentAccountSubtype;
+}
+
+export interface OtherAccountType extends BaseStandardizedAccountType {
+  type: AccountType.OTHER;
+}

--- a/packages/splice-api/src/ledger/index.ts
+++ b/packages/splice-api/src/ledger/index.ts
@@ -1,0 +1,2 @@
+export * from './account';
+export * from './transaction';

--- a/packages/splice-api/src/ledger/transaction.ts
+++ b/packages/splice-api/src/ledger/transaction.ts
@@ -1,0 +1,34 @@
+export interface StandardizedTransaction {
+  /** ID, this is Splice's record of the transaction, NOT the source's ID */
+  id: string;
+  /** ID of the account the transaction belongs to (Splice's record of the account) */
+  accountId: string;
+  /** Providers ID of the transaction (eg. Plaid transaction_id) */
+  providerTransactionId: string;
+  /** Providers ID of the account the transaction belongs to (eg. Plaid account_id) */
+  providerAccountId: string;
+  /** Amount of the transaction (positive for debit, negative for credit) */
+  amount: number;
+  /** ISO currency code (eg. USD, EUR) */
+  isoCurrencyCode?: string;
+  /** unofficial currency code (eg. for non-ISO currencies like crypto) */
+  unofficialCurrencyCode?: string;
+  /** Category for the transaction */
+  category?: TransactionCategory;
+  /** Date of the transaction (for pending: the date the transaction occurred, for posted: the date the transaction posted) */
+  date: string;
+  /** Name of the transaction (merchant name or transaction description) */
+  name: string;
+  /** Whether the transaction is pending */
+  pending: boolean;
+  /** Logo URL of the merchant */
+  logoUrl?: string;
+  /** Website URL of the merchant */
+  websiteUrl?: string;
+}
+
+export interface TransactionCategory {
+  primary: string;
+  detailed?: string;
+  confidenceLevel?: string;
+}

--- a/packages/splice-service/test/unit/bank-connections/bank-connection.service.spec.ts
+++ b/packages/splice-service/test/unit/bank-connections/bank-connection.service.spec.ts
@@ -237,10 +237,11 @@ describe('BankConnectionService', () => {
       {
         id: 'tx1',
         accountId: 'acc1',
+        providerTransactionId: 'tx1',
+        providerAccountId: 'acc1',
         date: '2024-01-01',
-        description: 'Test transaction',
+        name: 'Test transaction',
         amount: 100,
-        type: 'CREDIT' as const,
         pending: false,
       },
     ];

--- a/packages/splice-service/test/unit/data-sources/adapters/scraper.adapter.spec.ts
+++ b/packages/splice-service/test/unit/data-sources/adapters/scraper.adapter.spec.ts
@@ -222,13 +222,15 @@ describe('ScraperAdapter', () => {
       expect(result).toEqual([
         {
           id: `${mockConnectionId}-default`,
+          bankConnection: mockBankConnection,
+          providerAccountId: `${mockConnectionId}-default`,
           name: 'DBS Bank',
-          type: 'OTHER',
-          institution: 'DBS Bank',
-          metadata: {
-            connectionId: mockConnectionId,
-            scraperIdentifier: 'dbs',
+          mask: '1234',
+          type: {
+            type: 'DEPOSITORY',
+            subtype: 'SAVINGS',
           },
+          balances: {},
         },
       ]);
     });
@@ -267,67 +269,40 @@ describe('ScraperAdapter', () => {
       // Check first transaction (credit - negative amount becomes positive)
       expect(result[0]).toEqual({
         id: `${mockConnectionId}-DBS Savings Account-2024-01-15-REF001`,
-        accountId: `${mockConnectionId}-DBS Savings Account`,
+        accountId: `${mockAccountId}`,
+        providerTransactionId: 'REF001',
+        providerAccountId: `${mockAccountId}`,
         date: '2024-01-15',
-        description: 'REF001 - Transfer - From Checking - Online Banking',
-        amount: 100.5, // Absolute value
-        currency: 'SGD',
-        type: 'CREDIT', // Negative amount = CREDIT
+        name: 'REF001 - Transfer - From Checking - Online Banking',
+        amount: -100.5,
+        isoCurrencyCode: 'SGD',
         pending: false,
-        metadata: {
-          originalAmount: -100.5,
-          reference: 'REF001',
-          transactionRef1: 'Transfer',
-          transactionRef2: 'From Checking',
-          transactionRef3: 'Online Banking',
-          accountName: 'DBS Savings Account',
-          accountBalance: 5500.75,
-          accountType: 'savings_or_checking',
-        },
       });
 
       // Check second transaction (debit - positive amount)
       expect(result[1]).toEqual({
         id: `${mockConnectionId}-DBS Savings Account-2024-01-20-REF002`,
-        accountId: `${mockConnectionId}-DBS Savings Account`,
+        accountId: `${mockAccountId}`,
+        providerTransactionId: 'REF002',
+        providerAccountId: `${mockAccountId}`,
         date: '2024-01-20',
-        description: 'REF002 - Deposit - Salary',
+        name: 'REF002 - Deposit - Salary',
         amount: 2500.0,
-        currency: 'SGD',
-        type: 'DEBIT', // Positive amount = DEBIT
+        isoCurrencyCode: 'SGD',
         pending: false,
-        metadata: {
-          originalAmount: 2500.0,
-          reference: 'REF002',
-          transactionRef1: 'Deposit',
-          transactionRef2: 'Salary',
-          transactionRef3: '',
-          accountName: 'DBS Savings Account',
-          accountBalance: 5500.75,
-          accountType: 'savings_or_checking',
-        },
       });
 
       // Check credit card transaction
       expect(result[2]).toEqual({
         id: `${mockConnectionId}-DBS Credit Card-2024-01-10-REF003`,
-        accountId: `${mockConnectionId}-DBS Credit Card`,
+        accountId: `${mockAccountId}`,
+        providerTransactionId: 'REF003',
+        providerAccountId: `${mockAccountId}`,
         date: '2024-01-10',
-        description: 'REF003 - Purchase - Grocery Store - POS Transaction',
-        amount: 45.25, // Absolute value
-        currency: 'SGD',
-        type: 'CREDIT', // Negative amount = CREDIT
+        name: 'REF003 - Purchase - Grocery Store - POS Transaction',
+        amount: -45.25,
+        isoCurrencyCode: 'SGD',
         pending: false,
-        metadata: {
-          originalAmount: -45.25,
-          reference: 'REF003',
-          transactionRef1: 'Purchase',
-          transactionRef2: 'Grocery Store',
-          transactionRef3: 'POS Transaction',
-          accountName: 'DBS Credit Card',
-          accountBalance: -1200.0,
-          accountType: 'credit_card',
-        },
       });
     });
 


### PR DESCRIPTION
## Summary

This PR refactors the account and transaction type system by moving types from `data-sources` to a new dedicated `ledger` module and restructuring them for better type safety and extensibility.

### Key Changes

- **📁 New ledger module**: Created `packages/splice-api/src/ledger/` with dedicated account and transaction types
- **🏗️ Structured account types**: Replaced enum-based `StandardizedAccountType` with object-based `AccountType` system
- **🔧 Enhanced type safety**: Added detailed subtypes for different account categories (Depository, Credit, Investment)
- **🔗 Better relationships**: Added `bankConnection` reference and provider IDs to account/transaction entities
- **📊 Comprehensive mapping**: Updated Plaid adapter with extensive account type mapping (401k, brokerage, HSA, etc.)

### Type Structure Changes

**Before:**
```typescript
type: StandardizedAccountType.CHECKING
```

**After:**
```typescript
type: {
  type: AccountType.DEPOSITORY,
  subtype: DepositoryAccountSubtype.CHECKING
}
```

### Files Changed

- ✅ **New ledger module**: `account.ts`, `transaction.ts`, `index.ts`
- ✅ **Updated adapters**: PlaidAdapter and ScraperAdapter
- ✅ **Fixed tests**: All 205 tests passing with new structure
- ✅ **Package exports**: Added ledger module to main exports

## Test Plan

- [x] All existing unit tests updated and passing (205/205)
- [x] E2E tests passing
- [x] Lint checks passing
- [x] Type compilation successful
- [x] Plaid adapter correctly maps all account subtypes
- [x] Scraper adapter uses new account structure
- [x] Transaction structure includes provider IDs

## Breaking Changes

⚠️ **This is a breaking change** for any code using:
- `StandardizedAccountType` enum (now object-based)
- `StandardizedAccount.institution` field (now in `bankConnection`)
- `StandardizedTransaction.description` field (now `name`)

## Migration Path

Update imports and type usage:
```typescript
// Old
import { StandardizedAccountType } from 'splice-api'
type: StandardizedAccountType.CHECKING

// New  
import { AccountType, DepositoryAccountSubtype } from 'splice-api'
type: { type: AccountType.DEPOSITORY, subtype: DepositoryAccountSubtype.CHECKING }
```

🤖 Generated with [Claude Code](https://claude.ai/code)